### PR TITLE
JSON Responses for API calls

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,6 @@
 name: Run pytests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -83,11 +83,11 @@ def save_reading(metric_type: str, metric: str) -> Tuple[dict, int]:
         current_app.histograms[metric].record_value(value, labels=labels)
     else:
         return json_response(
-                    'Unsupported metric type (valid types are: {})'.format(
-                        ', '.join(supported_metrics)
-                    ),
-                    400
-                )
+            'Unsupported metric type (valid types are: {})'.format(
+                ', '.join(supported_metrics)
+            ),
+            400
+        )
 
     return json_response('Saved', 200)
 
@@ -120,10 +120,10 @@ def create_or_replace(metric_type: str, metric: str) -> Tuple[dict, int]:
         )
     else:
         return json_response(
-                    'Unsupported metric type (valid types are: {})'.format(
-                        ', '.join(supported_metrics)
-                    ),
-                    400
-                )
+            'Unsupported metric type (valid types are: {})'.format(
+                ', '.join(supported_metrics)
+            ),
+            400
+        )
 
     return json_response('Created', 201)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='tiny-exporter',
-      version='1.0.0',
+      version='1.1.0',
       description='',
       author='Mike Douglas',
       author_email='foo',

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -8,7 +8,6 @@ def test_save_gauge_reading_label(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
 
 
 def test_save_gauge_reading_no_label(client):
@@ -17,7 +16,6 @@ def test_save_gauge_reading_no_label(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
 
 
 def test_save_counter_reading_label(client):
@@ -27,7 +25,6 @@ def test_save_counter_reading_label(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
 
 
 def test_save_counter_reading_nolabel(client):
@@ -36,7 +33,6 @@ def test_save_counter_reading_nolabel(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
 
 
 def test_save_histogram_reading_label(client):
@@ -50,7 +46,6 @@ def test_save_histogram_reading_label(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
 
 
 def test_save_histogram_reading_nolabel(client):
@@ -59,4 +54,28 @@ def test_save_histogram_reading_nolabel(client):
     ))
 
     assert response.status_code == 200
-    assert response.data == b'OK'
+
+
+def test_configure_gauge_help_text(client):
+    response = client.put('/api/v2/metric/gauge/temp', json=dict(
+        help='Temperature'
+    ))
+
+    assert response.status_code == 201
+
+
+def test_configure_gauge_labels(client):
+    response = client.put('/api/v2/metric/gauge/temp', json=dict(
+        labels=dict(room='office')
+    ))
+
+    assert response.status_code == 201
+
+
+def test_configure_histogram_buckets(client):
+    response = client.put('/api/v2/metric/histogram/delivery_time', json=dict(
+        buckets=[120, 600, 1200, 2400, '+Inf']
+    ))
+
+    assert response.status_code == 201
+

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -78,4 +78,3 @@ def test_configure_histogram_buckets(client):
     ))
 
     assert response.status_code == 201
-


### PR DESCRIPTION
All `/api/` endpoints should now return a JSON response with a 4xx code (on error) or a 2xx code (on success).